### PR TITLE
docs(ci): tag → GitHub Release workflow + install via Releases

### DIFF
--- a/.github/workflows/ci-docs.md
+++ b/.github/workflows/ci-docs.md
@@ -16,14 +16,38 @@ Tracked on the fork as:
 | `Structure gates` | yes |
 | `iOS xcodebuild smoke` | soft (`continue-on-error`) |
 
-## Artifacts
+## Artifacts (CI)
 
 On green Android job:
 
 - `app-debug-apk` — installable debug APK
 - `socks-core-test-reports` — JUnit XML + HTML
 
-Retention: 14 days. Download from the Actions run page.
+Retention: 14 days. Download from the Actions run page. These are **per-run**
+smoke builds, not versioned releases.
+
+## Releases (tag → GitHub Release)
+
+Workflow: [`.github/workflows/release.yml`](release.yml)
+
+| Trigger | Output |
+|---------|--------|
+| Push annotated tag matching `v*` (e.g. `v0.1.0`) | GitHub Release + `app-debug.apk` asset |
+
+Maintainer steps:
+
+```bash
+git checkout main && git pull
+# confirm CI is green on this tip
+git tag -a vX.Y.Z -m "vX.Y.Z — summary"
+git push origin vX.Y.Z
+```
+
+The release job re-runs unit tests, assembles the debug APK, and attaches it with
+`gh release create`. APK is **unsigned debug** (sideload only). Play / App Store
+upload is intentionally out of scope (would need signing secrets).
+
+Existing example: https://github.com/Nanako0129/SocksBypass/releases/tag/v0.1.0
 
 ## Local parity
 
@@ -37,5 +61,8 @@ python3 Bench/socks_bench.py --mode self-test
 
 ## CD boundary
 
-This repo’s CD stops at **GitHub Actions artifacts**. Publishing to Google Play or
-the App Store needs signing secrets and is intentionally not automated here.
+| Path | What you get |
+|------|----------------|
+| CI on PR / `main` | Actions artifacts (14d) |
+| Tag `v*` | GitHub Release + APK (durable download link) |
+| Play / App Store | Not automated |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+# Tag → GitHub Release with installable debug APK
+# Usage: git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build APK + GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: android
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Install platform 36 + build-tools
+        run: |
+          sdkmanager --install "platforms;android-36" "build-tools;36.0.0" "platform-tools"
+          yes | sdkmanager --licenses >/dev/null || true
+          echo "sdk.dir=$ANDROID_HOME" > local.properties
+
+      - name: Unit tests (socks-core)
+        run: ./gradlew :socks-core:test --stacktrace --no-daemon
+
+      - name: Assemble debug APK
+        run: ./gradlew :app:assembleDebug --stacktrace --no-daemon
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          APK="android/app/build/outputs/apk/debug/app-debug.apk"
+          test -f "$APK"
+          NOTES="$(mktemp)"
+          cat >"$NOTES" <<EOF
+          ## ${TAG}
+
+          Automated release from tag \`${TAG}\`.
+
+          ### Android
+          - Debug APK: \`app-debug.apk\` (unsigned — sideload / testing only)
+          - Not Play Store / production signed
+
+          ### Install
+          1. Download \`app-debug.apk\` from Assets below
+          2. Enable install from unknown sources if needed
+          3. Open the phone **personal hotspot** → Start in app → SOCKS5 at shown IP:9876
+
+          See README for hotspot + cellular-bound behaviour.
+          EOF
+          gh release create "$TAG" "$APK" \
+            --title "${TAG}" \
+            --notes-file "$NOTES" \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ git clone https://github.com/Nanako0129/SocksBypass.git
 
 ### Android
 
+**Easiest — install a prebuilt APK**
+
+1. Open [Releases](https://github.com/Nanako0129/SocksBypass/releases) and download
+   `app-debug.apk` from the latest tag (e.g. [v0.1.0](https://github.com/Nanako0129/SocksBypass/releases/tag/v0.1.0)).
+2. On the phone, allow install from unknown sources if prompted, then open the APK.
+3. Follow [Usage → Android](#android-cellular-bound-proxy) (hotspot + Start).
+
+The release APK is an **unsigned debug** build for sideload/testing — not Play Store signed.
+
+**Or build from source**
+
 2. Open the Gradle project:
 ```bash
 cd android
@@ -190,7 +201,22 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on every PR and on `main` / `fe
 | **Structure** | yes | Android tree present, no Gradle in Xcode, FGS/`connectedDevice`/cellular/SDK gates |
 | **iOS smoke** | soft | `xcodebuild -list` + best-effort unsigned simulator build |
 
-**CD (today):** green Android jobs publish `app-debug.apk` and JUnit reports as Actions artifacts (14-day retention). Store upload is not automated.
+**CI artifacts:** green Android jobs upload `app-debug.apk` and JUnit reports (14-day retention on the Actions run page). Useful for PR smoke installs; not a versioned release.
+
+**Releases (normal path):** push an annotated tag `vX.Y.Z` on `main`.
+[`.github/workflows/release.yml`](.github/workflows/release.yml) builds the debug APK,
+runs unit tests, and creates a [GitHub Release](https://github.com/Nanako0129/SocksBypass/releases)
+with `app-debug.apk` attached.
+
+```bash
+# from a clean main tip that already passed CI
+git checkout main && git pull
+git tag -a v0.2.0 -m "v0.2.0 — short summary"
+git push origin v0.2.0
+# → Actions “Release” job → https://github.com/Nanako0129/SocksBypass/releases
+```
+
+Store upload (Play / App Store) is intentionally not automated here.
 
 Details: [`.github/workflows/ci-docs.md`](.github/workflows/ci-docs.md).
 
@@ -333,6 +359,14 @@ SOCKS5 core has since been rewritten in Swift and no longer contains microsocks.
 
 ## 安裝說明
 
+### Android（建議）
+
+從 [Releases](https://github.com/Nanako0129/SocksBypass/releases) 下載最新 `app-debug.apk`
+（例如 [v0.1.0](https://github.com/Nanako0129/SocksBypass/releases/tag/v0.1.0)），在手機上允許未知來源後安裝。
+這是**未簽名 debug 包**，僅供側載測試。開啟個人熱點 → app 內 Start → 客戶端 SOCKS5 指向顯示的 IP:9876。
+
+### iOS / 從原始碼建置
+
 1. Clone 專案：
 ```bash
 git clone https://github.com/Nanako0129/SocksBypass.git
@@ -347,6 +381,9 @@ git clone https://github.com/Nanako0129/SocksBypass.git
 - 將 iOS 裝置連接到電腦
 - 在 Xcode 中選擇你的裝置
 - 執行
+
+Android 原始碼建置：`cd android && ./gradlew :app:assembleDebug`，再
+`adb install -r app/build/outputs/apk/debug/app-debug.apk`。
 
 ## 使用方法
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml`: push annotated tag `v*` → unit tests + debug APK → GitHub Release asset
- README (EN + ZH): install Android from [Releases](https://github.com/Nanako0129/SocksBypass/releases) first; build-from-source still documented
- `ci-docs.md`: clarify CI artifacts (14d) vs tag Releases; document maintainer tag steps

## Context
`v0.1.0` was published manually after #6. This makes the same path automatic for the next tags.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: optional dry-run is `v0.1.0` already exists; next real tag will exercise Release workflow
- [ ] Dependabot triage (separate): merge only green small bumps verified as official bot id 49699333; defer majors / red CI