### PR TITLE
fix(relay): synthesize NAT64 for literal IPv4 targets, and a UDP ASSOCIATE declared-endpoint defect

### DIFF
--- a/SOCKS/App/RelayViewModel.swift
+++ b/SOCKS/App/RelayViewModel.swift
@@ -117,6 +117,8 @@ final class RelayViewModel: ObservableObject {
         case .connectRejected(let reply): return String(format: "CONNECT rejected 0x%02x", reply)
         case .udpAssociated: return "UDP ASSOCIATE established"
         case .udpAssociateFailed: return "UDP ASSOCIATE failed"
+        case .udpAssociateClosed(let uploaded, let downloaded, let preLatchRejected):
+            return "UDP ASSOCIATE closed (up: \(uploaded), down: \(downloaded), pre-latch rejected: \(preLatchRejected))"
         case .listenerFailed: return "listener failed — no longer accepting connections"
         }
     }

--- a/SOCKS/App/RelayViewModel.swift
+++ b/SOCKS/App/RelayViewModel.swift
@@ -117,8 +117,6 @@ final class RelayViewModel: ObservableObject {
         case .connectRejected(let reply): return String(format: "CONNECT rejected 0x%02x", reply)
         case .udpAssociated: return "UDP ASSOCIATE established"
         case .udpAssociateFailed: return "UDP ASSOCIATE failed"
-        case .udpAssociateClosed(let uploaded, let downloaded, let preLatchRejected):
-            return "UDP ASSOCIATE closed (up: \(uploaded), down: \(downloaded), pre-latch rejected: \(preLatchRejected))"
         case .listenerFailed: return "listener failed — no longer accepting connections"
         }
     }

--- a/SOCKS/Core/NetworkTCPRelay.swift
+++ b/SOCKS/Core/NetworkTCPRelay.swift
@@ -584,6 +584,15 @@ private final class RelaySession {
     /// (ordinary dual-stack/IPv4 networks, or a lookup failure) — that
     /// reproduces exactly the pre-existing direct-dial behavior, so this
     /// only changes anything on a network where the literal had no route.
+    ///
+    /// getaddrinfo() on a numeric IPv4 string can return more than one
+    /// result: the trivial AF_INET parse of the literal itself alongside a
+    /// synthesized AF_INET6 entry, in no guaranteed order — an IPv6-only
+    /// network was seen returning the AF_INET one first. Looking at only
+    /// `result` (the first entry) silently fell back to the literal every
+    /// time on such a network, i.e. this never actually did anything. Scan
+    /// every entry and prefer whichever one is AF_INET6, matching how
+    /// UdpAssociation.resolve() already walks the whole list.
     private static func synthesizedHost(for literal: String) -> NWEndpoint.Host {
         var hints = addrinfo()
         hints.ai_family = AF_UNSPEC
@@ -597,16 +606,20 @@ private final class RelaySession {
         }
         defer { Darwin.freeaddrinfo(first) }
 
-        guard first.pointee.ai_family == AF_INET6, let raw = first.pointee.ai_addr else {
-            return NWEndpoint.Host(literal)
+        var item: UnsafeMutablePointer<addrinfo>? = first
+        while let current = item {
+            let info = current.pointee
+            if info.ai_family == AF_INET6, let raw = info.ai_addr {
+                var address = sockaddr_in6()
+                memcpy(&address, raw, MemoryLayout<sockaddr_in6>.size)
+                let bytes = withUnsafeBytes(of: &address.sin6_addr) { Data($0) }
+                if let synthesized = IPv6Address(bytes) {
+                    return .ipv6(synthesized)
+                }
+            }
+            item = info.ai_next
         }
-        var address = sockaddr_in6()
-        memcpy(&address, raw, MemoryLayout<sockaddr_in6>.size)
-        let bytes = withUnsafeBytes(of: &address.sin6_addr) { Data($0) }
-        guard let synthesized = IPv6Address(bytes) else {
-            return NWEndpoint.Host(literal)
-        }
-        return .ipv6(synthesized)
+        return NWEndpoint.Host(literal)
     }
 
     /// The local address the outbound connection actually bound to, for BND.ADDR

--- a/SOCKS/Core/NetworkTCPRelay.swift
+++ b/SOCKS/Core/NetworkTCPRelay.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Network
 
@@ -271,6 +272,9 @@ private final class RelaySession {
     private var targetReadComplete = false
     private var handshakeReceivePending = false
     private var handshakeTimeout: DispatchWorkItem?
+    /// Bounds the getaddrinfo() round trip in beginTargetConnection's literal-IPv4
+    /// synthesis path; that call runs off-queue and has no timeout of its own.
+    private var synthesisTimeout: DispatchWorkItem?
     private var clientReceivePending = false
     private var targetReceivePending = false
     // A receive must never overtake the send carrying the previous payload. The
@@ -514,8 +518,50 @@ private final class RelaySession {
             return
         }
 
+        // NWEndpoint.Host(String) parses a string that already looks like an
+        // IPv4 literal straight into `.ipv4` and never asks the resolver
+        // anything; the NAT64 synthesis that makes an IPv6-only network reach
+        // an IPv4 destination only happens for the `.name` case, i.e. when
+        // resolution goes through a hostname. A CONNECT whose ATYP was a raw
+        // IPv4 address (as opposed to a domain) would otherwise dial an
+        // address the interface has no route for. getaddrinfo() performs the
+        // same synthesis for a numeric string as it does for a hostname, so
+        // route a literal through it before handing Network.framework a host.
+        guard IPv4Address(request.target.address) != nil else {
+            connectTarget(host: NWEndpoint.Host(request.target.address), port: port)
+            return
+        }
+
+        let address = request.target.address
+        let timeout = DispatchWorkItem { [weak self] in
+            guard let self, !self.cleaned, self.target == nil else { return }
+            self.synthesisTimeout = nil
+            self.sendRequestFailure(0x04)
+        }
+        synthesisTimeout = timeout
+        queue.asyncAfter(deadline: .now() + 5, execute: timeout)
+
+        Self.synthesisQueue.async { [weak self] in
+            let host = Self.synthesizedHost(for: address)
+            self?.queue.async {
+                guard let self else { return }
+                self.assertQueue()
+                // Already fired (or the session moved on) — don't also start a
+                // connection past that point.
+                guard let pending = self.synthesisTimeout else { return }
+                pending.cancel()
+                self.synthesisTimeout = nil
+                self.connectTarget(host: host, port: port)
+            }
+        }
+    }
+
+    private func connectTarget(host: NWEndpoint.Host, port: NWEndpoint.Port) {
+        assertQueue()
+        guard !cleaned, target == nil else { return }
+
         let target = NWConnection(
-            host: NWEndpoint.Host(request.target.address),
+            host: host,
             port: port,
             using: NetworkTCPRelay.makeTCPParameters()
         )
@@ -524,6 +570,43 @@ private final class RelaySession {
             self?.handleTargetState(state)
         }
         target.start(queue: queue)
+    }
+
+    /// Off the relay queue: getaddrinfo() is a blocking syscall and every
+    /// session shares that queue, so resolving on it would stall unrelated
+    /// connections for the DNS/synthesis round trip.
+    private static let synthesisQueue = DispatchQueue(
+        label: "com.nanako.socksbypass.benchmark.relay.tcp-synthesis",
+        qos: .utility
+    )
+
+    /// Falls back to the plain literal wherever synthesis doesn't apply
+    /// (ordinary dual-stack/IPv4 networks, or a lookup failure) — that
+    /// reproduces exactly the pre-existing direct-dial behavior, so this
+    /// only changes anything on a network where the literal had no route.
+    private static func synthesizedHost(for literal: String) -> NWEndpoint.Host {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_STREAM
+        hints.ai_protocol = IPPROTO_TCP
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = literal.withCString { Darwin.getaddrinfo($0, nil, &hints, &result) }
+        guard status == 0, let first = result else {
+            return NWEndpoint.Host(literal)
+        }
+        defer { Darwin.freeaddrinfo(first) }
+
+        guard first.pointee.ai_family == AF_INET6, let raw = first.pointee.ai_addr else {
+            return NWEndpoint.Host(literal)
+        }
+        var address = sockaddr_in6()
+        memcpy(&address, raw, MemoryLayout<sockaddr_in6>.size)
+        let bytes = withUnsafeBytes(of: &address.sin6_addr) { Data($0) }
+        guard let synthesized = IPv6Address(bytes) else {
+            return NWEndpoint.Host(literal)
+        }
+        return .ipv6(synthesized)
     }
 
     /// The local address the outbound connection actually bound to, for BND.ADDR
@@ -938,6 +1021,8 @@ private final class RelaySession {
         diagnose(reason)
         handshakeTimeout?.cancel()
         handshakeTimeout = nil
+        synthesisTimeout?.cancel()
+        synthesisTimeout = nil
         gracefulCloseTimeout?.cancel()
         gracefulCloseTimeout = nil
 

--- a/SOCKS/Core/NetworkTCPRelay.swift
+++ b/SOCKS/Core/NetworkTCPRelay.swift
@@ -12,6 +12,11 @@ final class NetworkTCPRelay {
         case connectRejected(reply: UInt8)
         case udpAssociated
         case udpAssociateFailed
+        /// Pure counts, no addresses or payload: how many datagrams from the
+        /// client this association ever recognized, how many reply datagrams
+        /// came back from a peer, and how many arrivals before the client
+        /// address latched didn't match the control peer and were dropped.
+        case udpAssociateClosed(uploaded: Int, downloaded: Int, preLatchRejected: Int)
         /// The listener died after it had already reported success. The start
         /// callback fires once, so without this the shell keeps showing a
         /// listening endpoint for a relay that stopped serving.
@@ -1030,9 +1035,14 @@ private final class RelaySession {
         target?.stateUpdateHandler = nil
         client.cancel()
         target?.cancel()
-        if udpAssociation != nil {
-            udpAssociation?.cancel()
-            udpAssociation = nil
+        if let udpAssociation {
+            emit(.udpAssociateClosed(
+                uploaded: udpAssociation.uploadedDatagramCount,
+                downloaded: udpAssociation.downloadedDatagramCount,
+                preLatchRejected: udpAssociation.preLatchRejectedCount
+            ))
+            udpAssociation.cancel()
+            self.udpAssociation = nil
             counters.associationClosed(id)
         }
         if active {

--- a/SOCKS/Core/NetworkTCPRelay.swift
+++ b/SOCKS/Core/NetworkTCPRelay.swift
@@ -12,11 +12,6 @@ final class NetworkTCPRelay {
         case connectRejected(reply: UInt8)
         case udpAssociated
         case udpAssociateFailed
-        /// Pure counts, no addresses or payload: how many datagrams from the
-        /// client this association ever recognized, how many reply datagrams
-        /// came back from a peer, and how many arrivals before the client
-        /// address latched didn't match the control peer and were dropped.
-        case udpAssociateClosed(uploaded: Int, downloaded: Int, preLatchRejected: Int)
         /// The listener died after it had already reported success. The start
         /// callback fires once, so without this the shell keeps showing a
         /// listening endpoint for a relay that stopped serving.
@@ -1036,11 +1031,6 @@ private final class RelaySession {
         client.cancel()
         target?.cancel()
         if let udpAssociation {
-            emit(.udpAssociateClosed(
-                uploaded: udpAssociation.uploadedDatagramCount,
-                downloaded: udpAssociation.downloadedDatagramCount,
-                preLatchRejected: udpAssociation.preLatchRejectedCount
-            ))
             udpAssociation.cancel()
             self.udpAssociation = nil
             counters.associationClosed(id)

--- a/SOCKS/Core/UdpAssociation.swift
+++ b/SOCKS/Core/UdpAssociation.swift
@@ -172,6 +172,13 @@ final class UdpAssociation {
             }
             return bytes[8..<24] == other.bytes[8..<24]
         }
+
+        /// The 16 raw address bytes alone, port and everything else stripped —
+        /// a stable key for host-only lookups.
+        var hostBytes: Data {
+            guard bytes.count >= 24 else { return Data() }
+            return bytes[8..<24]
+        }
     }
 
     private enum Resolution {
@@ -197,6 +204,21 @@ final class UdpAssociation {
     private var resolutions: [String: Resolution] = [:]
     /// Insertion order, so the cache can be evicted without a second index.
     private var resolutionOrder: [String] = []
+    /// Reverse of the above, ATYP IPv4 requests only: resolved destination
+    /// host bytes back to the literal the client actually addressed it as.
+    ///
+    /// A client that supplies a literal IPv4 target did its own resolution
+    /// and expects replies to appear to come from exactly that literal. When
+    /// the real send has to go out over a NAT64-synthesized address instead
+    /// (an IPv6-only network, no route for the literal itself), a reply's
+    /// source is that synthesized address, not the literal — reporting it
+    /// as-is hands the client a SOCKS5 UDP header whose source doesn't match
+    /// anything it dialed. A client tracking flows by that literal (seen on
+    /// tun2socks: "symmetric NAT ... drop packet from [64:ff9b::...]")
+    /// rejects the reply outright. This maps the observed source back to
+    /// what the client actually asked for.
+    private var literalIPv4ByDestinationHost: [Data: String] = [:]
+    private var literalIPv4Order: [Data] = []
     private var pendingResolutions = 0
     /// At most one datagram per in-flight lookup, replayed once it resolves.
     private var pendingDatagrams: [String: (payload: Data, port: UInt16)] = [:]
@@ -446,6 +468,9 @@ final class UdpAssociation {
                             return
                         }
                         self.resolutions[key] = .resolved(result)
+                        if decoded.header.addressType == .ipv4 {
+                            self.rememberLiteralIPv4(key, for: result)
+                        }
                         guard let queued else { return }
                         for destination in result
                         where self.send(queued.payload, to: destination.withPort(queued.port),
@@ -475,10 +500,41 @@ final class UdpAssociation {
         }
     }
 
+    /// Records, for each resolved destination, the literal IPv4 the client
+    /// addressed it as — so a reply arriving from a NAT64-synthesized address
+    /// can still be reported to the client as the address it actually dialed.
+    /// Bounded the same way the resolution cache is: this can only grow at
+    /// the same rate `resolutions` does, since every entry here traces back
+    /// to one ATYP IPv4 resolution.
+    private func rememberLiteralIPv4(_ literal: String, for destinations: [SocketAddress]) {
+        assertQueue()
+        for destination in destinations {
+            let hostKey = destination.hostBytes
+            guard !hostKey.isEmpty, literalIPv4ByDestinationHost[hostKey] == nil else { continue }
+            literalIPv4ByDestinationHost[hostKey] = literal
+            literalIPv4Order.append(hostKey)
+        }
+        while literalIPv4ByDestinationHost.count > Self.resolutionCacheLimit, !literalIPv4Order.isEmpty {
+            let oldest = literalIPv4Order.removeFirst()
+            literalIPv4ByDestinationHost.removeValue(forKey: oldest)
+        }
+    }
+
     private func handlePeerDatagram(_ payload: Data, from sourceAddress: SocketAddress) {
         assertQueue()
-        guard !closed, let clientAddress,
-              let (addressType, address) = Self.headerAddress(sourceAddress),
+        guard !closed, let clientAddress else { return }
+
+        // If this peer is answering a literal IPv4 the client dialed, report it
+        // back as that literal even though the real send went out over a
+        // NAT64-synthesized address — see literalIPv4ByDestinationHost.
+        let resolvedAddress: (AddressType, String)?
+        if let literal = literalIPv4ByDestinationHost[sourceAddress.hostBytes] {
+            resolvedAddress = (.ipv4, literal)
+        } else {
+            resolvedAddress = Self.headerAddress(sourceAddress)
+        }
+
+        guard let (addressType, address) = resolvedAddress,
               let packet = DatagramHeader.encode(
                 addressType: addressType,
                 address: address,

--- a/SOCKS/Core/UdpAssociation.swift
+++ b/SOCKS/Core/UdpAssociation.swift
@@ -189,6 +189,15 @@ final class UdpAssociation {
     private var closed = false
     private var clientAddress: SocketAddress?
     private let controlPeer: SocketAddress?
+    /// Pure counts, no addresses or payload — how many datagrams from the
+    /// client were recognized and processed, how many reply datagrams came
+    /// back from a peer, and how many arrivals before the client address
+    /// latched didn't match the control peer and were dropped. Diagnoses
+    /// "never relayed anything" vs. "relayed but never got a reply" without
+    /// exposing any traffic content.
+    private(set) var uploadedDatagramCount = 0
+    private(set) var downloadedDatagramCount = 0
+    private(set) var preLatchRejectedCount = 0
     private var resolutions: [String: Resolution] = [:]
     /// Insertion order, so the cache can be evicted without a second index.
     private var resolutionOrder: [String] = []
@@ -351,6 +360,7 @@ final class UdpAssociation {
             // and receive the real client's payload as if it were peer traffic.
             guard let controlPeer, sourceAddress.matchesHost(controlPeer),
                   DatagramHeader.decode(packet) != nil else {
+                preLatchRejectedCount += 1
                 return
             }
             clientAddress = sourceAddress
@@ -361,6 +371,7 @@ final class UdpAssociation {
     private func handleClientDatagram(_ packet: Data) {
         assertQueue()
         guard !closed, let decoded = DatagramHeader.decode(packet) else { return }
+        uploadedDatagramCount += 1
 
         switch decoded.header.addressType {
         case .ipv6:
@@ -465,6 +476,7 @@ final class UdpAssociation {
               ) else {
             return
         }
+        downloadedDatagramCount += 1
         _ = send(packet, to: clientAddress, direction: .download, committedBytes: payload.count)
     }
 

--- a/SOCKS/Core/UdpAssociation.swift
+++ b/SOCKS/Core/UdpAssociation.swift
@@ -346,6 +346,22 @@ final class UdpAssociation {
         if let clientAddress {
             if sourceAddress.matches(clientAddress) {
                 handleClientDatagram(packet)
+            } else if uploadedDatagramCount == 0,
+                      let controlPeer, sourceAddress.matchesHost(controlPeer),
+                      DatagramHeader.decode(packet) != nil {
+                // The UDP ASSOCIATE request declared a port up front, but some
+                // clients advertise a placeholder or a stale port rather than
+                // 0.0.0.0:0 — nothing has actually confirmed that declaration
+                // yet, so a well-formed datagram from the same host is far more
+                // likely the real client correcting it than an attacker. Without
+                // this, every datagram from that client is silently misfiled as
+                // a "peer reply" forever: the client's own SOCKS5 UDP forever
+                // gets echoed back to the wrong port and never reaches anything.
+                // Once real traffic has used an endpoint this no longer applies,
+                // matching the same same-host race the no-declaration path below
+                // already accepts.
+                self.clientAddress = sourceAddress
+                handleClientDatagram(packet)
             } else {
                 // There is intentionally no destination/NAT table. Every datagram
                 // from a non-client source is a peer payload and is wrapped verbatim

--- a/SOCKS/Core/UdpAssociation.swift
+++ b/SOCKS/Core/UdpAssociation.swift
@@ -363,14 +363,21 @@ final class UdpAssociation {
         guard !closed, let decoded = DatagramHeader.decode(packet) else { return }
 
         switch decoded.header.addressType {
-        case .ipv4, .ipv6:
+        case .ipv6:
             guard let destination = Self.numericAddress(
                 decoded.header.address,
                 port: decoded.header.port
             ) else { return }
             _ = send(decoded.payload, to: destination, direction: .upload)
 
-        case .domain:
+        case .ipv4, .domain:
+            // inet_pton (used by the .ipv6 path above) never synthesizes a NAT64
+            // address for an IPv4 literal; only getaddrinfo does, the same way it
+            // does for a hostname. On an IPv6-only network that difference is the
+            // whole story: numericAddress() would hand back an unroutable
+            // ::ffff:-mapped address and every datagram to it silently vanishes.
+            // Folding .ipv4 into the domain cache below gets it the same
+            // getaddrinfo() call .domain already makes.
             let key = decoded.header.address.lowercased()
             switch resolutions[key] {
             case .resolved(let destinations):

--- a/SOCKS/Core/UdpAssociation.swift
+++ b/SOCKS/Core/UdpAssociation.swift
@@ -189,15 +189,11 @@ final class UdpAssociation {
     private var closed = false
     private var clientAddress: SocketAddress?
     private let controlPeer: SocketAddress?
-    /// Pure counts, no addresses or payload — how many datagrams from the
-    /// client were recognized and processed, how many reply datagrams came
-    /// back from a peer, and how many arrivals before the client address
-    /// latched didn't match the control peer and were dropped. Diagnoses
-    /// "never relayed anything" vs. "relayed but never got a reply" without
-    /// exposing any traffic content.
-    private(set) var uploadedDatagramCount = 0
-    private(set) var downloadedDatagramCount = 0
-    private(set) var preLatchRejectedCount = 0
+    /// Whether a datagram has ever been confirmed on the current
+    /// `clientAddress`. Gates the declared-endpoint correction below: once
+    /// real traffic has used an endpoint, a mismatched sender goes back to
+    /// being treated as peer traffic rather than re-latching.
+    private var hasReceivedClientTraffic = false
     private var resolutions: [String: Resolution] = [:]
     /// Insertion order, so the cache can be evicted without a second index.
     private var resolutionOrder: [String] = []
@@ -346,7 +342,7 @@ final class UdpAssociation {
         if let clientAddress {
             if sourceAddress.matches(clientAddress) {
                 handleClientDatagram(packet)
-            } else if uploadedDatagramCount == 0,
+            } else if !hasReceivedClientTraffic,
                       let controlPeer, sourceAddress.matchesHost(controlPeer),
                       DatagramHeader.decode(packet) != nil {
                 // The UDP ASSOCIATE request declared a port up front, but some
@@ -376,7 +372,6 @@ final class UdpAssociation {
             // and receive the real client's payload as if it were peer traffic.
             guard let controlPeer, sourceAddress.matchesHost(controlPeer),
                   DatagramHeader.decode(packet) != nil else {
-                preLatchRejectedCount += 1
                 return
             }
             clientAddress = sourceAddress
@@ -387,7 +382,7 @@ final class UdpAssociation {
     private func handleClientDatagram(_ packet: Data) {
         assertQueue()
         guard !closed, let decoded = DatagramHeader.decode(packet) else { return }
-        uploadedDatagramCount += 1
+        hasReceivedClientTraffic = true
 
         switch decoded.header.addressType {
         case .ipv6:
@@ -492,7 +487,6 @@ final class UdpAssociation {
               ) else {
             return
         }
-        downloadedDatagramCount += 1
         _ = send(packet, to: clientAddress, direction: .download, committedBytes: payload.count)
     }
 

--- a/SocksBypassTests/UdpAssociationTests.swift
+++ b/SocksBypassTests/UdpAssociationTests.swift
@@ -159,6 +159,53 @@ final class UdpAssociationTests: XCTestCase {
         XCTAssertNil(stranger.receive(), "and must receive nothing back")
     }
 
+    /// Bug found via a real device (Discord voice over an IPv6-only hotspot,
+    /// Shadowrocket as the SOCKS5 client): the client declared a DST.PORT in
+    /// its UDP ASSOCIATE request that didn't match the port it actually sent
+    /// from. Every real datagram then failed the exact-address match against
+    /// the pre-latched (wrong) endpoint and was silently misfiled as "peer"
+    /// traffic — echoed back to the wrong port and never forwarded upstream —
+    /// so the client's own SOCKS5 UDP never reached anything, forever.
+    func testDeclaredEndpointWrongPortStillLatchesRealClient() throws {
+        let queue = DispatchQueue(label: "UdpAssociationTests.wrongDeclaredPort")
+        let counters = TrafficCounters(queue: queue, enabled: true)
+        let echo = try UdpTestSocket(family: AF_INET)
+        let realClient = try UdpTestSocket(family: AF_INET)
+        let association = try queue.sync {
+            try UdpAssociation(
+                queue: queue,
+                counters: counters,
+                localAddress: "127.0.0.1",
+                controlPeerAddress: "127.0.0.1",
+                // Deliberately wrong: some SOCKS5 clients advertise a stale or
+                // placeholder port rather than 0.0.0.0:0, and realClient's
+                // actual port is guaranteed not to be this one.
+                declaredClientEndpoint: (address: "127.0.0.1", port: 1),
+                onFailure: {}
+            )
+        }
+        defer { queue.sync { association.cancel() } }
+
+        let packet = try XCTUnwrap(
+            UdpAssociation.DatagramHeader.encode(
+                addressType: .ipv4, address: "127.0.0.1", port: echo.port, payload: Data([7, 7, 7])
+            )
+        )
+        XCTAssertTrue(realClient.send(packet, host: "127.0.0.1", port: association.localPort))
+        let echoed = try XCTUnwrap(echo.receiveAndEcho(), "the real client's datagram must still reach upstream")
+        XCTAssertEqual(echoed, Data([7, 7, 7]))
+        let reply = try XCTUnwrap(realClient.receive())
+        XCTAssertEqual(UdpAssociation.DatagramHeader.decode(reply)?.payload, Data([7, 7, 7]))
+
+        // Once real traffic has used an endpoint, a second same-host source must
+        // go back to being treated as peer traffic, same as the no-declaration
+        // path: the correction window is one-shot, not a standing exception.
+        let stranger = try UdpTestSocket(family: AF_INET)
+        XCTAssertTrue(stranger.send(packet, host: "127.0.0.1", port: association.localPort))
+        XCTAssertNil(echo.receiveAndEcho(timeout: 0.2))
+        XCTAssertNil(stranger.receive(timeout: 0.2))
+    }
+
     /// Review finding: getaddrinfo AF_INET results were cached as sockaddr_in and
     /// then rejected by the dual-stack socket, so A-only names silently dropped
     /// every datagram. "127.0.0.1" as a domain resolves to IPv4 only.


### PR DESCRIPTION
## Summary

Three bugs, all found via real-device testing on an IPv6-only/NAT64 personal hotspot, across three different SOCKS5 clients (Android/SocksTun, iOS+macOS/Shadowrocket, Windows/tun2socks):

### 1. UDP literal IPv4 targets bypass NAT64 synthesis

`inet_pton()` short-circuits a string that already parses as an IPv4 literal straight to a raw address, skipping the resolver entirely. NAT64 synthesis only fires when resolution goes through a hostname, so on an IPv6-only interface a UDP ASSOCIATE target that arrived as a raw IPv4 address (ATYP 0x01) had no route and datagrams just vanished, while the identical domain-based target worked fine.

`SOCKS/Core/UdpAssociation.swift`: fold the `.ipv4` ATYP case into the existing domain-resolution/`getaddrinfo()` cache pipeline instead of the raw `inet_pton()` fast path. `.ipv6` is untouched.

**Verified on-device**: fixed Discord voice UDP for the Android/SocksTun client.

### 2. TCP literal IPv4 targets: same bug, and the first fix attempt didn't work

Same root cause on the CONNECT path — `NWEndpoint.Host(String)` parses a literal straight to `.ipv4`, skipping resolution. First attempt added a `getaddrinfo()`-based synthesis step, but it only inspected the *first* result from the call. On this network, `getaddrinfo()` on a numeric IPv4 string returns more than one entry — the trivial AF_INET parse of the literal itself alongside a synthesized AF_INET6 entry — with the AF_INET one first. So the fix silently fell back to the original (unroutable) literal every single time; it never actually did anything, and went undetected because every literal-IP TCP CONNECT exercised in earlier testing (Discord) happened to be domain-based, not literal.

Caught via tun2socks on Windows: it resolves DNS locally at the TUN packet layer and so sends almost every CONNECT as a literal IP, unlike Shadowrocket which mostly forwards the original hostname. `naver.com` worked through the patched server via Shadowrocket (domain-based, unaffected) but failed with "general SOCKS server failure" via tun2socks (literal IP, hit the broken fallback) — same server, same target, different client behavior, which is what isolated it.

`SOCKS/Core/NetworkTCPRelay.swift`: walk every entry in the `getaddrinfo()` result list via `ai_next` and use whichever one is AF_INET6, matching how `UdpAssociation.resolve()` already does it. Still falls back to the literal if no AF_INET6 entry appears anywhere in the list (ordinary dual-stack/IPv4 networks, or a genuine lookup failure).

**Verified on-device**: fixed literal-IP TCP CONNECT (e.g. `naver.com` resolved locally) for the Windows/tun2socks client.

### 3. UDP ASSOCIATE declared-endpoint port mismatch misfiles all client traffic

RFC1928 lets a UDP ASSOCIATE request declare the port the client will send from; this server pre-latches `clientAddress` to it so a same-host process can't race the real client for the association (see d8e916b/2880d6f). Shadowrocket (iOS/macOS) declares a port that isn't where it actually sends from. Every real datagram then failed the exact-address match against the wrong pre-latched endpoint and fell into the "no destination table, anything unmatched is peer traffic" branch — the client's own outbound SOCKS5 UDP got echoed back to the wrong port as if it were a reply, and nothing ever reached upstream. Diagnosed with a temporary counter (added and later removed in this branch's history): 0 datagrams from the client were ever recognized, despite the association reporting success.

`SOCKS/Core/UdpAssociation.swift`: while nothing has yet been confirmed on the declared endpoint, a well-formed datagram from the control peer's *host* on a different port is treated as the client correcting an inaccurate declaration, and `clientAddress` re-latches to it — the same same-host race the no-declaration fallback path already accepts, and it stops applying the moment real traffic has used an endpoint. Doesn't relax the d8e916b hardening, just stops the port-narrowing part of it from permanently misrouting a client whose declared port turns out to be wrong.

New regression test `testDeclaredEndpointWrongPortStillLatchesRealClient`: a wrong declared port must not block the real client, and after real traffic has flowed, a second same-host source must still be rejected as peer traffic.

**Verified on-device**: fixed Discord voice for the Shadowrocket clients on both iPad and macOS.

## Test plan

- [x] On-device, IPv6-only/NAT64 hotspot, Android/SocksTun client: Discord voice call connects and stays connected
- [x] On-device, same hotspot, iOS/Shadowrocket and macOS/Shadowrocket clients: Discord voice call connects and stays connected
- [x] On-device, same hotspot, Windows/tun2socks client: literal-IP TCP CONNECT (`naver.com`, previously "general SOCKS server failure") now connects
- [x] `xcodebuild build` succeeds (Debug config) — built and run on-device by the reporter for all three test passes above
- [ ] `SocksBypassTests` pass, especially `NetworkTCPRelayTests`, `UdpAssociationTests` (includes new `testDeclaredEndpointWrongPortStillLatchesRealClient`) — not run separately from the on-device testing above
- [ ] Regression check on a normal dual-stack/IPv4 network: no behavior change for any of the three fixes