### PR TITLE
chore(ci): group Dependabot Gradle bumps and ignore platform breakers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 # Keep Actions and Gradle plugins from rotting.
+# AndroidX / Kotlin major-or-platform jumps often need a coordinated AGP +
+# compileSdk upgrade; group related bumps and ignore known breakers until then.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -12,3 +14,26 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      # Avoid half-upgrades like kotlin.jvm alone vs kotlin.android / compose.
+      kotlin-plugins:
+        patterns:
+          - "org.jetbrains.kotlin.*"
+      # One PR for lifecycle-runtime-ktx / viewmodel-compose / runtime-compose.
+      androidx-lifecycle:
+        patterns:
+          - "androidx.lifecycle*"
+    ignore:
+      # core-ktx ≥ ~1.17/1.19 needs compileSdk 37 + AGP ≥ 9.1 (see closed #20).
+      # Revisit after the Android platform upgrade PR lands.
+      - dependency-name: "androidx.core:core-ktx"
+        versions: [">=1.17.0"]
+      - dependency-name: "androidx.core:core"
+        versions: [">=1.17.0"]
+      # lifecycle 2.11.x same AGP/SDK floor (see closed #14 / #24 / #26).
+      - dependency-name: "androidx.lifecycle*"
+        versions: [">=2.10.0"]
+      # Kotlin 2.4+ rejects kotlinOptions.jvmTarget string DSL and must move
+      # android + jvm + compose together (see closed #23 / #25).
+      - dependency-name: "org.jetbrains.kotlin.*"
+        versions: [">=2.1.0"]


### PR DESCRIPTION
## Summary
- Group Gradle Dependabot updates: ``kotlin-plugins`` (``org.jetbrains.kotlin.*``) and ``androidx-lifecycle`` so we stop getting half-upgrades / duplicate PRs.
- Ignore known CI breakers on the current toolchain (AGP 8.10.1, compileSdk 36, Kotlin 2.0.21):
  - ``androidx.core`` ≥ 1.17 (needs AGP 9.1 + compileSdk 37; closed #20)
  - ``androidx.lifecycle`` ≥ 2.10 (same floor; closed #14 / #24 / #26)
  - ``org.jetbrains.kotlin.*`` ≥ 2.1 (2.4 rejects ``kotlinOptions.jvmTarget`` string DSL; closed #23 / #25)
- GitHub Actions ecosystem unchanged (weekly, limit 5).

## Why
Dependabot was opening real version bumps that cannot land as solo PRs. Closing the red PRs alone does not stop the next weekly cycle; this config reduces noise until we do a coordinated platform upgrade.

## Test plan
- [x] YAML only under ``.github/dependabot.yml``
- [ ] CI green on this PR (structure / android / bench — no Android source change)
- [ ] After merge, next Dependabot run does not re-open the ignored ranges as solo breakers

Related: closed #20 #23 #24 #25 #26